### PR TITLE
Chore | WI 64 | Project Tile Missing Image

### DIFF
--- a/src/app/components/ui/ProjectTile.tsx
+++ b/src/app/components/ui/ProjectTile.tsx
@@ -45,7 +45,7 @@ export default function ProjectTile({
           />
         ) : (
           <div className={`${imageStyle}`}>
-            <Github />
+            <Github width={imageSize[0] * 0.75} height={imageSize[1] * 0.75} className={imageStyle}/>
           </div>
         )}
       </div>


### PR DESCRIPTION
fix: add width and height props to Github icon in ProjectTile component

Closes #64 